### PR TITLE
Fix: gh pages上でCSS, JSが表示されない問題の修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,9 @@ concurrency:
   group: "pages"
   cancel-in-progress: false
 
+env:
+  NODE_ENV: "production"
+
 jobs:
   deploy:
     environment:

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,9 +1,14 @@
 import type { NextConfig } from "next";
 
+const isProduction = process.env.NODE_ENV === 'production';
+const repoName = 'ios-to-google-ime-dictionary';
+const basePath = isProduction ? `/${repoName}` : '';
+
 const nextConfig: NextConfig = {
   /* config options here */
   reactStrictMode: true,
   output: 'export',
+  basePath: basePath,
 };
 
 export default nextConfig;


### PR DESCRIPTION
## What's changed

- Production build時に Next.js の basePathを設定するように変更
    - FYI: https://nextjs.org/docs/app/api-reference/config/next-config-js/basePath

## Background

2025/03/21 時点では、https://iori-oshima.github.io/ios-to-google-ime-dictionary/ に *.html は配信されていたが、 *.css, *.js が読み込まれていなかった。
これは、gh pagesは（特別な場合を除いて） `<username>.github.io/<reooname>` をベースパスとして解釈するが、GHAの中で `<username>.github.io/` をベースパスとしていた不一致に起因していた。

この不一致を解消して、適切にJS, CSSが配信されるようにしたい
