### PR TITLE
Fix: GitHub Actionsの修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,9 +34,12 @@ jobs:
         with:
           node-version: '22'
 
-      - name: Install dependencies and build
+      - name: Install dependencies
         run: |
-          npm ci
+          npm install
+
+      - name: Build
+        run: |
           npm run build
 
       - name: Setup Pages


### PR DESCRIPTION
follow up: #16 

## What's changed

`npm ci` を `npm i` にリバート...

## Why

Build時にdevDependenciesに依存しており、 npm ci経由だとこれが落ちてこないから。。（後で直す）